### PR TITLE
fix(FileUploadRename): may throw a null pointer exception

### DIFF
--- a/app/src/main/java/top/sacz/timtool/hook/item/chat/FileUploadRename.kt
+++ b/app/src/main/java/top/sacz/timtool/hook/item/chat/FileUploadRename.kt
@@ -70,9 +70,11 @@ class FileUploadRename : BaseSwitchFunctionHookItem() {
         hookBefore(troopMethod, { param ->
             val item = param.args[1]
             val fileName: String = FieldUtils.getField(item, "FileName", String::class.java)
-            val localFile: String = FieldUtils.getField(item, "LocalFile", String::class.java)
-            if (meetHitConditions(fileName, localFile)) {
-                FieldUtils.setField(item, "FileName", getFormattedFileNameByPath(localFile))
+            val localFile: String? = FieldUtils.getField(item, "LocalFile", String::class.java)
+            localFile?.let { file ->
+                if (meetHitConditions(fileName, file)) {
+                    FieldUtils.setField(item, "FileName", getFormattedFileNameByPath(file))
+                }
             }
         }, 25)
         hookBefore(troopMethod, { param ->


### PR DESCRIPTION
修复(文件上传重命名): 第一次打开群文件时, LocalFile可能为空从而抛出的空指针异常